### PR TITLE
处理JS引擎执行先后顺序随机的问题

### DIFF
--- a/src/scripts/bilibili-ban-pcdn/video.ts
+++ b/src/scripts/bilibili-ban-pcdn/video.ts
@@ -98,14 +98,17 @@ export default (useLogger: (name) => ConsoleLogger, getConfig: (key: string) => 
     })
   }
   // 播放器初始化参数
-  let __playinfo__ = pageWindow.__playinfo__
+  let __playinfo__ = pageWindow.__playinfo__;
   Object.defineProperty(pageWindow, "__playinfo__", {
-    get: () => __playinfo__,
-    set: (value: PlayInfo) => {
-      log("初始化参数", value)
-      cleanPlayInfo(value)
-      __playinfo__ = value
-    },
+      get: () => {
+          cleanPlayInfo(__playinfo__);
+          return __playinfo__;
+      },
+      set: (value) => {
+       log("初始化参数", value)
+       cleanPlayInfo(value)
+       __playinfo__ = value
+      },
   })
   // 播放列表请求处理
   const originalXHR = pageWindow.XMLHttpRequest


### PR DESCRIPTION
有的时候页面的源码会硬编码dash链接，尝试通过hook nano.CreatePlayer()的方式处理这些链接